### PR TITLE
tmp fix YTM failing fetch of album metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ CHANGES
 `Unreleased <https://github.com/fmigneault/aiu/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Fix invalid attempts to retrieve `album` and `artist` name from metadata with possibly unavailable field.
+* Fix invalid attempts to retrieve ``album`` and ``artist`` name from metadata with possibly unavailable field
+  (use patch: `fmigneault/python-youtube-music@patch-new-youtube-music-version <
+   https://github.com/fmigneault/python-youtube-music/tree/patch-new-youtube-music-version>`_,
+   relates to: `tombulled/python-youtube-music#13 <https://github.com/tombulled/python-youtube-music/issues/13>`_).
 
 `1.5.0 <https://github.com/fmigneault/aiu/tree/1.5.0>`_ (2021-08-27)
 ------------------------------------------------------------------------------------

--- a/aiu/youtube.py
+++ b/aiu/youtube.py
@@ -84,7 +84,6 @@ class CachedYoutubeMusicDL(YouTubeMusicDL):
         LOGGER.debug(msg, *_)
 
 
-
 class TqdmYouTubeMusicDL(CachedYoutubeMusicDL):
     """
     Setup hooks around methods that process the `download album` operation to display progress per track downloaded.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,8 @@ requests
 typing
 tqdm
 youtube_dl
-#git+https://github.com/tombulled/python-youtube-music#egg=ytm[dl]
-git+https://github.com/fmigneault/python-youtube-music@fix-illegal-chars#egg=ytm[dl]
+# FIXME: until merged (https://github.com/tombulled/python-youtube-music/pull/14)
+#   should try using 'innertube' instead
+#   (https://github.com/tombulled/python-youtube-music/issues/13#issuecomment-923262424)
+# git+https://github.com/tombulled/python-youtube-music#egg=ytm[dl]
+git+https://github.com/fmigneault/python-youtube-music@patch-new-youtube-music-version#egg=ytm[dl]


### PR DESCRIPTION
- relates to https://github.com/tombulled/python-youtube-music/issues/13
- patched by https://github.com/fmigneault/python-youtube-music/tree/patch-new-youtube-music-version
- resolved by https://github.com/tombulled/python-youtube-music/pull/14