### PR TITLE
add support of YouTube Music channel links multi-album download

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ CHANGES
 `Unreleased <https://github.com/fmigneault/aiu/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Add support of input YouTube Music channel link to automatically download and process all available artist albums.
+  Individual albums are iteratively processed as separate ``aiu`` operations and downloaded songs are stored into
+  corresponding album sub-directories.
 
 `1.6.0 <https://github.com/fmigneault/aiu/tree/1.6.0>`_ (2021-09-22)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ CHANGES
 * Add ``--nP`` and ``--no-progress`` argument to allow disabling only progress bars while keeping more verbose logging.
 * Add ``--no-summary`` to better represent ``--no-result`` argument behaviour.
 * Replace ``--nP`` by ``--nS`` for argument ``--no-result``.
+* Fix failing resolution of single ``AudioInfo`` element (single audio file) due to ``Duration`` field not allowing
+  additional positional arguments during deepcopy.
 
 `1.6.0 <https://github.com/fmigneault/aiu/tree/1.6.0>`_ (2021-09-22)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,15 @@ CHANGES
 * Add support of input YouTube Music channel link to automatically download and process all available artist albums.
   Individual albums are iteratively processed as separate ``aiu`` operations and downloaded songs are stored into
   corresponding album sub-directories.
+* Fix incorrect direct reference to ``YoutubeMusicDL`` instead of ``CachedYoutubeMusicDL`` implementation when
+  no ``tqdm`` progression is requested.
+* Fix base YouTube downloader to employ ``yt_dlp`` instead of ``youtube_dl``, providing download speed
+  improvements and other YouTube related issue handling.
+* Fix displayed SSL warnings caused by underlying YouTube downloader requests that cannot be addressed
+  directly by this tool.
+* Add ``--nP`` and ``--no-progress`` argument to allow disabling only progress bars while keeping more verbose logging.
+* Add ``--no-summary`` to better represent ``--no-result`` argument behaviour.
+* Replace ``--nP`` by ``--nS`` for argument ``--no-result``.
 
 `1.6.0 <https://github.com/fmigneault/aiu/tree/1.6.0>`_ (2021-09-22)
 ------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -145,3 +145,24 @@ It is possible to provide a YouTube Music URL formatted with the album ID in que
 When providing such a link to `AIU` (with the ``--link`` option), it can simultaneously retrieve the corresponding
 album audio files and apply all appropriate audio tag metadata to them. The resulting files can then be further
 updated using the other options and parsing formats from metadata configurations.
+
+.. _ytm_multi_link:
+
+Process multiple artist albums from YouTube Music link
+======================================================
+
+If the provided ``--link`` corresponds to a YouTube Music channel URL, all albums of this artist will be downloaded.
+
+::
+
+    https://music.youtube.com/channel/<ARTIST_ID>
+
+Album songs will be stored into corresponding sub-directories under the specified output location.
+
+Note that according to the amount of songs per albums and total albums, this operation can take some time, but it
+will at least save the user the manual work of running individual ``aiu`` call per album link.
+
+Other ``aiu`` parameters are also still applicable when using this type of link
+(e.g.: ``--artist``, ``--prefix-track``, etc.).
+Be mindful of provided flags though to make sure they remain relevant, since they will be applied to all albums
+to be processed for that artist.

--- a/aiu/main.py
+++ b/aiu/main.py
@@ -31,7 +31,14 @@ from aiu.parser import (
     save_audio_config
 )
 from aiu.updater import merge_audio_configs, apply_audio_config, update_file_names
-from aiu.utils import backup_files, look_for_default_file, save_cover_file, validate_output_file, log_exception
+from aiu.utils import (
+    backup_files,
+    log_exception,
+    look_for_default_file,
+    make_dirs_cleaned,
+    save_cover_file,
+    validate_output_file
+)
 from aiu.typedefs import AudioConfig, Duration
 from aiu.youtube import fetch_files, get_artist_albums, get_metadata
 
@@ -371,7 +378,7 @@ def main(
             LOGGER.warning("Will not fetch files from URL in 'dry' mode. Enforcing '--no-fetch'.")
             no_fetch = True
         elif not dry:
-            os.makedirs(output_dir, exist_ok=True)
+            make_dirs_cleaned(output_dir, exist_ok=True)
         LOGGER.info("Retrieving config 'youtube'%s from link: [%s]", "" if no_fetch else " and album files", link)
         progress_display = force_progress or (LOGGER.isEnabledFor(logging.INFO) and not no_progress)
         albums = get_artist_albums(link, throw=False)

--- a/aiu/typedefs.py
+++ b/aiu/typedefs.py
@@ -112,7 +112,7 @@ class Duration(BaseField, datetime.timedelta):
         Duration(datetime.timedelta(hours=1, minutes=23, seconds=45))
         Duration(5025)  # int == 1*3600 + 23*60 + 45 seconds
     """
-    def __new__(cls, duration=None, **kwargs):
+    def __new__(cls, duration=None, *_, **kwargs):
         if isinstance(duration, str):
             time_parts = duration.replace("-", ":").replace("/", ":").split(":")
             h, m, s = [None] + time_parts if len(time_parts) == 2 else time_parts

--- a/aiu/utils.py
+++ b/aiu/utils.py
@@ -10,6 +10,8 @@ from PIL import Image
 from aiu.typedefs import AudioConfig, AudioFileAny, AudioFile, AudioInfo, CoverFileAny, CoverFile, LoggerType
 from aiu import LOGGER
 
+REGEX_FILENAME_ILLEGAL_CHARS = re.compile(r"[\"\\:?*<>|]")
+
 
 def log_exception(logger=None):
     # type: (LoggerType) -> Callable
@@ -123,7 +125,7 @@ def make_dirs_cleaned(path, replace="-", exist_ok=True, mode=0o755):
             top_path, dir_path = os.path.split(dir_path)
             if not top_path or not dir_path:
                 break
-            parts.append(re.sub(r"[^\w\-_\. ]", replace, dir_path))
+            parts.append(re.sub(REGEX_FILENAME_ILLEGAL_CHARS, replace, dir_path))
             dir_path = top_path
             if os.path.isdir(top_path):
                 break

--- a/aiu/youtube.py
+++ b/aiu/youtube.py
@@ -13,6 +13,7 @@ from ytm.types.ids.ArtistId import ArtistId
 from ytm import utils as ytm_utils
 
 from aiu import LOGGER
+from aiu.utils import make_dirs_cleaned
 from aiu.parser import fetch_image
 from aiu.typedefs import Duration
 
@@ -289,6 +290,7 @@ def fetch_files(link, output_dir, with_cover=True, progress_display=True):
     LOGGER.debug("Fetching files from link: [%s]", link)
     api = TqdmYouTubeMusicDL() if progress_display else CachedYoutubeMusicDL()
     is_album, is_music, ref_id = get_reference_id(link)
+    make_dirs_cleaned(output_dir)
     if is_album and is_music:
         meta = api.download_album(ref_id, output_dir)  # pre-applied ID3 tags
     else:  # any single music/video

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
+mock
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ requests
 typing
 tqdm
 youtube_dl
-# FIXME: until merged (https://github.com/tombulled/python-youtube-music/pull/14)
+# FIXME:
 #   should try using 'innertube' instead
 #   (https://github.com/tombulled/python-youtube-music/issues/13#issuecomment-923262424)
+# FIXME: until merged (https://github.com/tombulled/python-youtube-music/pull/17)
 # git+https://github.com/tombulled/python-youtube-music#egg=ytm[dl]
-git+https://github.com/fmigneault/python-youtube-music@patch-new-youtube-music-version#egg=ytm[dl]
+git+https://github.com/fmigneault/python-youtube-music@fix-artist-playlist-id#egg=ytm[dl]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,11 @@ PyYAML
 requests
 typing
 tqdm
-youtube_dl
+yt-dlp
+#youtube_dl @ git+https://github.com/yt-dlp/yt-dlp
 # FIXME:
 #   should try using 'innertube' instead
 #   (https://github.com/tombulled/python-youtube-music/issues/13#issuecomment-923262424)
 # FIXME: until merged (https://github.com/tombulled/python-youtube-music/pull/17)
 # git+https://github.com/tombulled/python-youtube-music#egg=ytm[dl]
-git+https://github.com/fmigneault/python-youtube-music@fix-artist-playlist-id#egg=ytm[dl]
+git+https://github.com/fmigneault/python-youtube-music@fix-artist-playlist-id+youtube-dl-impl#egg=ytm[dl]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import mock
+import os
+import platform
+
+from aiu.utils import make_dirs_cleaned
+
+
+def test_make_dirs_cleaned():
+    default_args = {"mode": 0o755, "exist_ok": True}
+    cur_dir = os.path.realpath(".")
+    path_prefix = os.path.splitdrive(cur_dir)[0] if platform.system() == "Windows" else ""
+
+    def _fix_path(_path):
+        _prefix = path_prefix if not _path.startswith(path_prefix) else ""
+        return os.path.normpath(_prefix + _path)
+
+    valid_tests = [
+        "/tmp/random/valid",
+        "/tmp/random/also valid",
+    ]
+    invalid_tests = [
+        ("/tmp/random/not!valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not ok?", _fix_path("/tmp/random/not ok-")),
+        ("./ok/yes|no/good/not:good", _fix_path(cur_dir + "/ok/yes-no/good/not-good"))
+    ]
+
+    with mock.patch("os.makedirs") as mkdir_mock:
+        for test_dir in valid_tests:
+            result_dir = _fix_path(test_dir)
+            make_dirs_cleaned(test_dir)
+            mkdir_mock.assert_called_with(result_dir, **default_args)
+        for test_dir, result_dir in invalid_tests:
+            make_dirs_cleaned(test_dir)
+            mkdir_mock.assert_called_with(result_dir, **default_args)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,11 +17,22 @@ def test_make_dirs_cleaned():
     valid_tests = [
         "/tmp/random/valid",
         "/tmp/random/also valid",
+        "/tmp/random/is allowed!",
+        "/tmp/random/~~all-good~~",
+        "/tmp/random/[also] good",
+        "/tmp/random/(also) good",
     ]
     invalid_tests = [
-        ("/tmp/random/not!valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not\"valid", _fix_path("/tmp/random/not-valid")),
+        # ("/tmp/random/not\\valid", _fix_path("/tmp/random/not-valid")),  # cannot test on Windows since it gets split
+        ("/tmp/random/not:valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not?valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not*valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not<valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not>valid", _fix_path("/tmp/random/not-valid")),
+        ("/tmp/random/not|valid", _fix_path("/tmp/random/not-valid")),
         ("/tmp/random/not ok?", _fix_path("/tmp/random/not ok-")),
-        ("./ok/yes|no/good/not:good", _fix_path(cur_dir + "/ok/yes-no/good/not-good"))
+        ("./ok/yes|no/good/not:good", _fix_path(cur_dir + "/ok/yes-no/good/not-good")),
     ]
 
     with mock.patch("os.makedirs") as mkdir_mock:


### PR DESCRIPTION
- add support of YouTube Music channel links multi-album download
- improve reporting of progress bars to display multi-albums, songs and download progresses
- add flags to allow explicit display or disable of progress bars
- depend on https://github.com/tombulled/python-youtube-music/pull/17 to fix `artist` metadata retrieval (used to retrieve its albums)
- depend on https://github.com/tombulled/python-youtube-music/pull/18 for `YoutubeDL` override with https://github.com/yt-dlp/yt-dlp implementation