### PR TITLE
update yt-dlp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 `Unreleased <https://github.com/fmigneault/aiu/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Fix missing encoding when writing JSON temp file metadata that contains characters needing UTF-8.
+* Fix ``LP_OVERLAPPED`` error by upgrading requirement of ``yt-dlp`` with more recent version.
 
 `1.7.0 <https://github.com/fmigneault/aiu/tree/1.7.0>`_ (2022-01-08)
 ------------------------------------------------------------------------------------

--- a/aiu/youtube.py
+++ b/aiu/youtube.py
@@ -267,7 +267,7 @@ def update_metadata(meta, fetch_cover=False):
         if track is not None:
             track += 1
 
-    with tempfile.NamedTemporaryFile("w") as file:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8") as file:
         json.dump(meta, file, indent=4, ensure_ascii=False)
     return file.name, meta["tracks"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ PyYAML
 requests
 typing
 tqdm
-yt-dlp
+yt-dlp>=2022.4.8
 #youtube_dl @ git+https://github.com/yt-dlp/yt-dlp
 # FIXME:
 #   should try using 'innertube' instead


### PR DESCRIPTION
# changes
* Fix missing encoding when writing JSON temp file metadata that contains characters needing UTF-8.
* Fix ``LP_OVERLAPPED`` error by upgrading requirement of ``yt-dlp`` with more recent version.