### PR TITLE
fixes for better reporting outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 `Unreleased <https://github.com/fmigneault/aiu/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Update `TODO <TODO.md>`_ items that have been implemented in previous versions.
+
 
 `1.7.2 <https://github.com/fmigneault/aiu/tree/1.7.2>`_ (2022-08-16)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ CHANGES
 ------------------------------------------------------------------------------------
 
 * Update `TODO <TODO.md>`_ items that have been implemented in previous versions.
-
+* Set default logging level to `INFO` (i.e.: `-v` option) to provide basic steps and progress bar details.
+* Fix reported ``cover`` field in generated output configuration to use the saved image within the output
+  location instead of the temporary location employed for downloading the YouTube album/song cover.
+* Fix missing properties to better handle ``CoverFile`` class attributes.
 
 `1.7.2 <https://github.com/fmigneault/aiu/tree/1.7.2>`_ (2022-08-16)
 ------------------------------------------------------------------------------------

--- a/TODO.md
+++ b/TODO.md
@@ -5,20 +5,12 @@ Various things that remain to be done but planned.
 Reference: https://readthedocs.org/projects/eyed3/downloads/pdf/latest/
 
 
-1. apply album cover, working command as follows: 
-	```
-	eyeD3 --force-update --remove-all-images --add-image "cover.jpg:FRONT_COVER" <directory>
-	```
-	
-	maybe use `<CONDA_ENV>/Lib/site-packages/eyed3/plugins/art.py` 
-	or basic CLI `<CONDA_ENV>/Lib/site-packages/eyed3/plugins/classic.py`
-	
-2. remove random comments using following command: 
+1. remove random comments using following command: 
 	```
     eyeD3 --user-text-frame "comment:" <directory>
 	```
 
-3. override Album types based on detected from album-name (`[Singles]`, `[EP]`, etc.) or via explicit arg:
+2. override Album types based on detected from album-name (`[Singles]`, `[EP]`, etc.) or via explicit arg:
     (as per `<CONDA_ENV>/Lib/site-packages/eyed3/plugins/fixup.py`)
 
     - ``lp``: A traditional "album" of songs from a single artist.
@@ -39,19 +31,14 @@ Reference: https://readthedocs.org/projects/eyed3/downloads/pdf/latest/
       it has album metadata). The string 'single' is written to the tag's
       ``%(TXXX_ALBUM_TYPE)s`` field.
 
-4. apply total tracks number from number of songs listed in info file. 
+3. apply total tracks number from number of songs listed in info file. 
 	if album type is singles, ignore (reset) this value to be "none" (in case previously written)
 	ie: 
 	```
 	eyeD3 -D <TOTAL> <directory>
 	```
 	
-5. apply artist, contrib-artist, album name, genre and year to ID3 Tags + (any other fields?)
-	```
-	eyeD3 --album <ALBUM> --album-artist <ALBUM ARTIST> --artist <ARTIST> --year <YEAR> --genre <GENRE>
-	```
-
-6. add `--detail` arg that retrieves ID3 tag listing information by calling (default is to list tags info)
+4. add `--detail` arg that retrieves ID3 tag listing information by calling (default is to list tags info)
     ```
     eyeD3 <directory>
     ```

--- a/aiu/main.py
+++ b/aiu/main.py
@@ -37,6 +37,7 @@ from aiu.utils import (
     look_for_default_file,
     make_dirs_cleaned,
     save_cover_file,
+    update_cover_file,
     validate_output_file
 )
 from aiu.typedefs import AudioConfig, Duration
@@ -267,7 +268,7 @@ def cli():
             if args.pop(arg, False) and logger_level == NOTSET:
                 logger_level = lvl
         if logger_level == NOTSET:
-            logger_level = ERROR
+            logger_level = INFO
         LOGGER.setLevel(logger_level)
     except Exception as exc:
         exc = exc if LOGGER.isEnabledFor(DEBUG) else False
@@ -530,7 +531,8 @@ def main(
 
     # save the cover file when it was fetched from youtube music link and not provided explicitly as override
     if not dry and not no_cover and not cover_file and link and not no_fetch:
-        save_cover_file(output_config, output_dir)
+        cover_file = save_cover_file(output_config, output_dir)
+        update_cover_file(output_config, cover_file)
 
     # report results
     if not no_output and not save_audio_config(output_config, output_file, mode=output_mode, dry=dry):

--- a/aiu/parser.py
+++ b/aiu/parser.py
@@ -369,6 +369,12 @@ _FETCHED_CACHE = {}
 
 
 def fetch_image(link, output_dir=None):
+    # type: (str, Optional[str]) -> str
+    """
+    Retrieve the image from a reference URL and save it locally, or return the local path if already available.
+
+    Images retrieved from URL will be cached for direct access on following calls.
+    """
     global _FETCHED_CACHE
 
     # avoid over requesting to reduce transfer + avoid rate-limiting

--- a/aiu/utils.py
+++ b/aiu/utils.py
@@ -78,7 +78,7 @@ def get_cover_file(cover_file):
 
 
 def save_cover_file(config, output_dir):
-    # type: (AudioConfig, str) -> None
+    # type: (AudioConfig, str) -> Optional[str]
     """
     Searches for any album image cover file within the audio configuration files and saves it.
 
@@ -89,11 +89,26 @@ def save_cover_file(config, output_dir):
         if cfg.cover is not None:
             if os.path.isfile(path):
                 LOGGER.warning("Could not save cover image, file already exists: [%s]", path)
-                return
+                return path
             LOGGER.warning("Saved cover image: [%s]", path)
             cfg.cover.save(path)
-            return
+            return path
     LOGGER.warning("Could not find any cover image to save. Operation skipped.")
+
+
+def update_cover_file(config, cover_file):
+    # type: (AudioConfig, Union[str, CoverFile]) -> None
+    """
+    Apply the new cover file to audio files if they mismatch.
+    """
+    if isinstance(cover_file, CoverFile):
+        cover_file = cover_file.path
+    for file_cfg in config:
+        prev_cover = file_cfg.get("cover")
+        if cover_file and (not prev_cover or cover_file != prev_cover.path):
+            LOGGER.debug("Updating temporary cover image [%s] -> [%s] for [%s].",
+                         prev_cover.path, cover_file, file_cfg.file)
+            file_cfg.cover = cover_file
 
 
 def validate_output_file(output_file_path, search_path, default_name="output.cfg"):


### PR DESCRIPTION
# Changes

* Update `TODO <TODO.md>`_ items that have been implemented in previous versions.
* Set default logging level to `INFO` (i.e.: `-v` option) to provide basic steps and progress bar details.
* Fix reported ``cover`` field in generated output configuration to use the saved image within the output
  location instead of the temporary location employed for downloading the YouTube album/song cover.
* Fix missing properties to better handle ``CoverFile`` class attributes.