### PR TITLE
add multiple new heuristics to improve file name matching + fixes and improvements for logging and CLI parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,10 @@ CHANGES
   provided explicitly to be ignored.
 * Remove duplicate and unimplemented function for applying ID3 tags.
 * Move ID3 tag and cover file utilities from ``aiu.utils`` to ``aiu.updater`` module.
-* Fix ID3 tags configuration passed by individual options (``-A``, ``-T``, etc.)
+* Fix ID3 tags properties passed by individual options (``-A``, ``-T``, etc.) to be incorrectly reported in the logging
+  definition, as well as passing them as individual ``AudioInfo`` objects instead of a single combined one under the
+  generated ``AudioConfig`` for these tags. If more than one literal ID3 tag field was provided simultaneously, this
+  would cause erroneous mismatches in length comparison between multiple ``AudioConfig`` from the various sources.
 * Fix logging calls not using the lazy string evaluation format in some cases.
 
 `1.10.1 <https://github.com/fmigneault/aiu/tree/1.10.1>`_ (2023-07-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,35 @@ CHANGES
 `Unreleased <https://github.com/fmigneault/aiu/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Add search path override to output directory location when the current directory path is detected as the script path.
+* Add ``--no-heuristic-tag-match`` and corresponding ``heuristic_tag_match`` flag applied by default that will attempt
+  matching existing ID3 tags from the source audio files against target configuration ID3 tags when file names were not
+  sufficient to find a match.
+* Add more file name matching heuristics to consider duplicated descriptors across multiple file names, in order to
+  reduce the set of false-positive candidates using only word portions of the title that are distinct and descriptive.
+* Add options ``--heuristic-stopword`` and ``--heuristic-config`` that allows providing a set of stopwords to be ignored
+  only during the heuristic file name matching strategy. These allow removing words often found in file names that cause
+  noise for the purpose of matching the audio file title. The default file employed if no parameters for these options
+  are unspecified is ``aiu/config/ignore.cfg``.
+* Rename ``aiu.Config.EXCEPTIONS`` and ``aiu.Config.STOPWORDS`` to ``aiu.Config.EXCEPTIONS_RENAME`` and
+  ``aiu.Config.STOPWORDS_RENAME`` respectively to distinguish them from new ``aiu.Config.STOPWORDS_MATCH``
+  employed by ``--heuristic-stopword`` and ``--heuristic-config``.
+* Add alternative option names ``--rename-exceptions-config`` and ``--rename-stopwords-config`` to corresponding
+  ``--exceptions`` and ``--stopwords`` options to provide more explicit representation of their purpose.
+* Fix ``heuristic_word_match`` and ``heuristic_delete_duplicates`` flags not passed down for iterative per-album call.
+* Apply the resolved ``album_artist`` ID3 tag or its default value set by ``artist`` ID3 tag according to options
+  ``--no-match-artist`` and ``--album-artist`` as detailed in their description.
+* Fix default value of ``match_artist``, set when omitting ``-no-match-artist`` that caused ``--album-artist`` value
+  provided explicitly to be ignored.
+* Remove duplicate and unimplemented function for applying ID3 tags.
+* Move ID3 tag and cover file utilities from ``aiu.utils`` to ``aiu.updater`` module.
+* Fix ID3 tags configuration passed by individual options (``-A``, ``-T``, etc.)
+* Fix logging calls not using the lazy string evaluation format in some cases.
 
 `1.10.1 <https://github.com/fmigneault/aiu/tree/1.10.1>`_ (2023-07-04)
 ------------------------------------------------------------------------------------
 
-* Add ``Makefile`` target ``version`` to quickly retreive the information to facilitate use with ``bump`` targets.
+* Add ``Makefile`` target ``version`` to quickly retrieve the information to facilitate use with ``bump`` targets.
 * Fixes to ``Makefile`` and ``setup.py`` encountering issues on reinstall.
 
 `1.10.0 <https://github.com/fmigneault/aiu/tree/1.10.0>`_ (2023-06-28)

--- a/aiu/__init__.py
+++ b/aiu/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional
 import logging
 import os
 import sys
@@ -12,18 +12,19 @@ AIU_PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
 AIU_ROOT_DIR = os.path.dirname(AIU_PACKAGE_DIR)
 AIU_CONFIG_DIR = os.path.join(AIU_ROOT_DIR, "config")
 
-if TYPE_CHECKING:
-    StopwordsType = Optional[List[str]]
-    ExceptionsType = Optional[Dict[str, str]]
+StopwordsType = Optional[List[str]]
+ExceptionsType = Optional[Dict[str, str]]
 
 
 class Config:
-    STOPWORDS = None    # type: StopwordsType
-    EXCEPTIONS = None   # type: ExceptionsType
+    EXCEPTIONS_RENAME = None    # type: ExceptionsType
+    STOPWORDS_RENAME = None     # type: StopwordsType
+    STOPWORDS_MATCH = None      # type: StopwordsType
 
 
 DEFAULT_STOPWORDS_CONFIG = os.path.join(AIU_CONFIG_DIR, "stopwords.cfg")
 DEFAULT_EXCEPTIONS_CONFIG = os.path.join(AIU_CONFIG_DIR, "exceptions.cfg")
+DEFAULT_STOPWORDS_MATCH = os.path.join(AIU_CONFIG_DIR, "ignore.cfg")
 AIU_SETUP_CONFIG = os.path.join(AIU_ROOT_DIR, "setup.cfg")
 
 

--- a/aiu/clean.py
+++ b/aiu/clean.py
@@ -23,9 +23,9 @@ def beautify_string(s):
             s = s.replace(c, ' ')
     while '  ' in s:
         s = s.replace('  ', ' ')
-    if aiu.Config.STOPWORDS:
+    if aiu.Config.STOPWORDS_RENAME:
         word_sep_list = re.split(r'(\W+)', s)
-        s = ''.join(w.capitalize() if w not in aiu.Config.STOPWORDS else w.lower() for w in word_sep_list)
+        s = ''.join(w.capitalize() if w not in aiu.Config.STOPWORDS_RENAME else w.lower() for w in word_sep_list)
     words = s.split(' ', maxsplit=1)
     words = words[0].capitalize() + (' ' + words[1] if len(words) > 1 else '')
     for punctuation in PUNCTUATIONS:
@@ -37,8 +37,8 @@ def beautify_string(s):
                 else:
                     parts[p] = parts[p][0].upper() + parts[p][1:]
         words = punctuation.join(parts)
-    if aiu.Config.EXCEPTIONS:
-        for k, w in aiu.Config.EXCEPTIONS.items():
+    if aiu.Config.EXCEPTIONS_RENAME:
+        for k, w in aiu.Config.EXCEPTIONS_RENAME.items():
             if k.lower() in words:
                 words = words.replace(k.lower(), w)
     return words

--- a/aiu/updater.py
+++ b/aiu/updater.py
@@ -1,20 +1,26 @@
 import os
 import re
 from copy import deepcopy
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple, TypeVar
 from unicodedata import normalize
 from difflib import SequenceMatcher
 
-from aiu.typedefs import AudioConfig, AudioFileAny, AudioInfo, AudioTagDict, CoverFileAny
+import eyed3
+from PIL import Image
+
+import aiu
+from aiu import StopwordsType
+from aiu.tags import TAG_TITLE
+from aiu.typedefs import AudioConfig, AudioFile, AudioFileAny, AudioInfo, AudioTagDict, CoverFile, CoverFileAny
 from aiu.utils import (
+    COMMON_WORD_IGNORE_CHARS,
     COMMON_WORD_REPLACE_CHARS,
     COMMON_WORD_SPLIT_CHARS,
-    FILENAME_ILLEGAL_CHARS,
-    FILENAME_ILLEGAL_CHARS_REGEX,
-    get_audio_file,
-    get_cover_file
+    FILENAME_ILLEGAL_CHARS_REGEX
 )
-from aiu import LOGGER, Config
+from aiu import LOGGER
+
+MatchT = TypeVar("MatchT", bound=Iterable)
 
 
 def merge_audio_configs(configs, match_artist, audio_files, config_shared, delete_duplicate):
@@ -44,7 +50,8 @@ def merge_audio_configs(configs, match_artist, audio_files, config_shared, delet
         inconsistency if they can be validated as duplicates to other files.
     :return: merged config.
     """
-    total_files = len(list(audio_files))
+    audio_files = list(audio_files)
+    total_files = len(audio_files)
     max_audio_count = max(len(cfg[1]) for cfg in configs)
     if config_shared or all(cfg[0] for cfg in configs):
         max_audio_count = total_files
@@ -78,14 +85,16 @@ def merge_audio_configs(configs, match_artist, audio_files, config_shared, delet
                         "Please resolve missing items manually."
                     ).format(max_audio_count, cfg_size)
                 )
-        else:
+        elif cfg_size != max_audio_count:
             # following configs updates the first as required
-            if cfg_size != max_audio_count:
-                # FIXME: not implemented
-                pass
-
-
-                #for c in cfg[1]:
+            # FIXME: not implemented
+            LOGGER.warning(
+                "Use case not implemented for CFG_SIZE (%s) != MAX_AUDIO_COUNT (%s)! Skipping.",
+                cfg_size, max_audio_count
+            )
+    if match_artist:
+        for config in merged_config:
+            config.album_artist = config.artist
     return merged_config
 
 
@@ -100,7 +109,7 @@ def filter_duplicates(file_paths):
     # (e.g.: 'This Song!' and 'This Song_' [corrected rename] should match)
     match_name_threshold = 0.95
     # to ensure consistency, any potential duplicate should also have very close content size
-    # size threshold can be much more strict - files should almost perfectly match
+    # threshold can be much more strict - files should almost perfectly match
     # allow some leeway to consider distinct ID3 values which will slightly affect the file size,
     # but not as much as the actual audio data
     match_size_threshold = 0.95
@@ -110,7 +119,7 @@ def filter_duplicates(file_paths):
     file_sizes = {name: float(os.stat(file).st_size) for name, file in zip(file_names, file_paths)}
     match_results = [
         (
-            # for each name, compare against all other files, and obtain best fuzzy match
+            # for each name, compare against all other files, and obtain the best fuzzy match
             compute_best_match(name, file_names[:i] + file_names[i + 1:]),  # (index, name, ratio)
             (name, path)
         )
@@ -151,7 +160,9 @@ def filter_duplicates(file_paths):
 
 def update_audio_tags(audio_file, audio_tags, overwrite=True):
     # type: (AudioFileAny, AudioTagDict, Optional[bool]) -> None
-    """Updates the audio file using provided audio tags."""
+    """
+    Updates the audio file using provided audio tags.
+    """
     audio_file = get_audio_file(audio_file)
     if not isinstance(audio_tags, dict):
         raise TypeError("Audio tag dict expected.")
@@ -167,16 +178,85 @@ def update_audio_tags(audio_file, audio_tags, overwrite=True):
     audio_file.tag.save()
 
 
-def update_cover_image(audio_file, cover_file, overwrite=True):
-    # type: (AudioFileAny, CoverFileAny, Optional[bool]) -> None
-    """Update the album cover tag of an audio file using the provided cover image file."""
-    audio_file = get_audio_file(audio_file)
-    cover_file = get_cover_file(cover_file)
-    raise NotImplementedError  # TODO
+def get_audio_file(audio_file):
+    # type: (AudioFileAny) -> AudioFile
+    """
+    Obtains the audio file by path or compatible objects.
+    """
+    if isinstance(audio_file, str):
+        audio_file = eyed3.load(audio_file)
+    if not isinstance(audio_file, AudioFile):
+        raise TypeError("Audio file expected.")
+    return audio_file
 
 
-def compute_best_match(text, choices):
-    # type: (str, Iterable[str]) -> Tuple[int, str, float]
+def get_cover_file(cover_file):
+    # type: (CoverFileAny) -> CoverFile
+    """
+    Obtains the cover file by path or compatible objects.
+    """
+    if isinstance(cover_file, str):
+        cover_file = Image.open(cover_file)
+    if not isinstance(cover_file, CoverFile):
+        raise TypeError("Cover file expected.")
+    return cover_file
+
+
+def save_cover_file(config, output_dir):
+    # type: (AudioConfig, str) -> Optional[str]
+    """
+    Searches for any album image cover file within the audio configuration files and saves it.
+
+    Only saves the first match, assuming all audio files belong to the same album and share the same cover.
+    """
+    path = os.path.join(output_dir, "cover.png")
+    for cfg in config:
+        if cfg.cover is not None:
+            if os.path.isfile(path):
+                LOGGER.warning("Could not save cover image, file already exists: [%s]", path)
+                return path
+            LOGGER.warning("Saved cover image: [%s]", path)
+            cfg.cover.save(path)
+            return path
+    LOGGER.warning("Could not find any cover image to save. Operation skipped.")
+
+
+def update_cover_file(config, cover_file):
+    # type: (AudioConfig, CoverFileAny) -> None
+    """
+    Apply the new cover file to audio files if they mismatch.
+    """
+    if isinstance(cover_file, CoverFile):
+        cover_file = cover_file.path
+    for file_cfg in config:
+        prev_cover = file_cfg.get("cover")
+        if cover_file and (not prev_cover or cover_file != prev_cover.path):
+            LOGGER.debug("Updating temporary cover image [%s] -> [%s] for [%s].",
+                         prev_cover.path, cover_file, file_cfg.file)
+            file_cfg.cover = cover_file
+
+
+def filter_shared_items(choices):
+    # type: (List[MatchT]) -> List[MatchT]
+    """
+    Removes the longest prefix or suffix items shared across all choices of variable size.
+    """
+    if len(choices) < 2:
+        return choices
+    max_subset = min(len(choice) for choice in choices) - 1
+    for length in reversed(range(1, max_subset + 1)):
+        first = choices[0]
+        prefix = first[:length]
+        suffix = first[length:]
+        if all(other[:length] == prefix for other in choices[1:]):
+            return [choice[length:] for choice in choices]
+        if all(other[length:] == suffix for other in choices[1:]):
+            return [choice[:length] for choice in choices]
+    return choices
+
+
+def compute_best_match(search, choices):
+    # type: (MatchT, Iterable[MatchT]) -> Tuple[int, MatchT, float]
     """
     Selects the best matching string amongst multiple choices with fuzzy matching.
 
@@ -185,79 +265,148 @@ def compute_best_match(text, choices):
     """
     results = []
     for i, test in enumerate(choices):
-        ratio = SequenceMatcher(None, text, test).ratio()
+        ratio = SequenceMatcher(None, search, test).ratio()
         results.append((i, test, ratio))
     results = sorted(results, key=lambda r: r[-1], reverse=True)
     return results[0]
 
 
-def clean_words(text):
-    # type: (str) -> List[str]
+def clean_words(text, stopwords):
+    # type: (str, StopwordsType) -> List[str]
     """
     Clean up common characters exceptions and splits the resulting words from the cleaned text.
     """
-    for char in FILENAME_ILLEGAL_CHARS + COMMON_WORD_SPLIT_CHARS:
+    for char in COMMON_WORD_SPLIT_CHARS:
         text = text.replace(char, " ")
     for from_char, to_char in COMMON_WORD_REPLACE_CHARS.items():
         text = text.replace(from_char, to_char)
     words = text.lower().split(" ")
-    words = [word for word in words if word not in Config.STOPWORDS]
+    stopwords = set(stopwords) | COMMON_WORD_IGNORE_CHARS
+    words = [word for word in words if word and word not in stopwords]
     return words
 
 
-def compute_word_match(search_files, search_info):
-    # type: (List[str], List[AudioInfo]) -> Dict[str, Optional[AudioInfo]]
+def compute_word_match(search_files, search_info, threshold_match_words=0.6):
+    # type: (List[str], List[AudioInfo], float) -> Dict[str, Optional[AudioInfo]]
     """
     Attempts to associate files by name with corresponding audio information with heuristic word matching.
+
+    :param search_files: List of file names, paths or plain titles of these files to attempt matching.
+    :param search_info: Reference information against which matching must be attempted.
+    :param threshold_match_words:
+        Threshold for which the word sequence would be considered a match with sufficient overlap between the
+        source file title and the destination audio information. This value should be sufficiently low to allow
+        some extra words that are not matched between the two sets, but sufficiently high to avoid matching anything.
     """
-    matches = {}
+    search_file_words = [
+        (file, clean_words(os.path.splitext(os.path.split(file)[-1])[0], aiu.Config.STOPWORDS_MATCH))
+        for file in search_files
+    ]
+    search_audio_words = [
+        clean_words(info.title, aiu.Config.STOPWORDS_MATCH)
+        for info in search_info
+    ]
+    # A common scenario that causes no matches is when multiple files share a part of their name perfectly.
+    # For example, when multiple songs are prefixed with their corresponding artist or album name.
+    # These shared words are usually not included in the target words of the titles to match against,
+    # which causes all matching attempts to yield a low score.
+    # Remove them to increase matches using only discriminative words between available choices.
+    filtered_file_words = filter_shared_items([words for _, words in search_file_words])
+    search_file_words = [(search[0], words) for search, words in zip(search_file_words, filtered_file_words)]
 
-    search_file_words = {file: clean_words(os.path.split(file)[-1]) for file in search_files}
-    search_title_words = {str(info.title): clean_words(info.title) for info in search_info}
-    search_title_audio = {str(info.title): info for info in search_info}
-
-    # very loose match to allow many extra words
-    # take into account that only leftover/unmatched items should remain
-    threshold_match_words = 0.6
-
-    for file, sf_words in search_file_words.items():
+    matches = {}  # type: Dict[str, Optional[AudioInfo]]
+    for file, sf_words in search_file_words:
         matches[file] = None
-        for ai_title, ai_words in search_title_words.items():
-            audio_info = search_title_audio[ai_title]
-            ratio = SequenceMatcher(None, sf_words, ai_words).ratio()
-            if ratio > threshold_match_words:
-                if not matches[file]:
-                    LOGGER.debug("Found potential word match for [%s] with [%s] (%0.2f%% match)",
-                                 file, audio_info.title, ratio)
-                    matches[file] = (ratio, audio_info)
-                elif matches[file] and matches[file][0] < ratio:
-                    LOGGER.debug("Found better word match for [%s] with [%s] (%0.2f%% match, %0.2f%% previous)",
-                                 file, audio_info.title, ratio, matches[file][0])
-                    matches[file] = (ratio, audio_info)
+        sf_match = compute_best_match(sf_words, search_audio_words)
+        sf_ratio = sf_match[2]
+        if sf_ratio > threshold_match_words:
+            sf_index = sf_match[0]
+            audio_info = search_info[sf_index]
+            LOGGER.debug("Found potential word match for [%s] with [%s] (%0.2f%% match).",
+                         file, audio_info.title, sf_ratio)
+            matches[file] = audio_info
+        else:
+            LOGGER.debug("No word match found for [%s]. Too low score (%0.2f%% match).", file, sf_ratio)
 
     # ensure no conflicting matches
     for file in search_files:
         other_files = set(search_files) - {file}
         if not matches[file]:
             continue
-        if not all(not matches[other] or matches[other][1] is not matches[file][1] for other in other_files):
+        if not all(not matches[other] or matches[other] is not matches[file] for other in other_files):
             # remove shared match (conflict)
             # ensure removal everywhere, not just the current 'file' checked to avoid leaving one as unique match
-            cur_info = matches[file][1]
+            cur_info = matches[file]
             for dup_file in search_files:
-                if matches[dup_file] and matches[dup_file][1] is cur_info:
+                if matches[dup_file] and matches[dup_file] is cur_info:
                     LOGGER.debug("Potential word match for [%s] with [%s] caused duplicate, dropping it.",
                                  dup_file, cur_info.title)
                     matches[dup_file] = None
-    for file in list(matches):
-        if matches[file]:
-            LOGGER.debug("Found unique word match for [%s] with [%s].", file, matches[file][1].title)
-            matches[file] = matches[file][1]  # return expected format, dropping the temporary ratio
     return matches
 
 
-def apply_audio_config(audio_files, audio_config, use_word_match=True, dry=False):
-    # type: (Iterable[str], AudioConfig, bool, bool) -> AudioConfig
+def compute_tag_match(search_files, search_info, word_match=False):
+    # type: (List[str], List[AudioInfo], bool) -> Dict[str, Optional[AudioInfo]]
+    """
+    Attempts to associate files by name with corresponding audio information with ID3 tag matching.
+    """
+    pseudo_search_files = {}
+    for audio_file_path in search_files:
+        audio_file = get_audio_file(audio_file_path)
+        audio_title = getattr(audio_file.tag, TAG_TITLE, None)
+        if not audio_title:
+            continue
+        pseudo_search_files[audio_title] = audio_file_path
+
+    if word_match:
+        word_matches = compute_word_match(list(pseudo_search_files), search_info)
+        matches = {
+            pseudo_search_files[audio_title]: audio_info
+            for audio_title, audio_info
+            in word_matches.items()
+        }
+        return matches
+
+    matches = {}
+    for audio_title, audio_file_path in pseudo_search_files.items():
+        for audio_info in search_info:
+            if audio_title == audio_info.title:
+                LOGGER.debug("Found exact match for [%s] using ID3 tag.", audio_file_path)
+                search_info.remove(audio_info)
+                matches[audio_file_path] = audio_info
+                break
+    return matches
+
+
+def check_last_item(search_files, search_audio):
+    # type: (List[str], List[AudioInfo]) -> Dict[str, Optional[AudioInfo]]
+    """
+    Last resort check if there is only a single item remaining to match.
+
+    In some cases, the remaining item that could not be matched against any of the previous heuristics is simply caused
+    by the (purposely) *too strict* threshold used to avoid over-matching between multiple similar candidate items.
+    A common example where one item remains unmatched is when audio information provides a "featuring ..." portion in
+    the title, while the actual file name does not provide it, or vice-versa. Because this "featuring ..." part adds
+    more words only on one side, the computed similarity necessarily yields a lower matching score. However, the
+    difference is usually only slightly lower than what would be needed to be above the threshold (1-2 word off).
+
+    In the situation where only one item to match remains, the risk of over-matching is greatly reduced, because all
+    other relatively similar candidates should have been removed already from another audio information with much
+    higher matching scores, from previous heuristics. Therefore, attempt validating a match with a looser threshold.
+
+    A match *MUST* still be validated, even if only one item remains.
+    Otherwise, an irrelevant name that was correctly unmatched could suddenly become "matched" erroneously.
+    """
+    matches = {}
+    if len(search_files) == 1 and len(search_audio) == 1:
+        matches = compute_word_match(search_files, search_audio, threshold_match_words=0.4)
+        if matches:
+            LOGGER.debug("Found last-item word match for [%s].", search_files[0])
+    return matches
+
+
+def apply_audio_config(audio_files, audio_config, use_tag_match=True, use_word_match=True, dry=False):
+    # type: (Iterable[str], AudioConfig, bool, bool, bool) -> AudioConfig
     """
     Applies the metadata fields to the corresponding audio files.
 
@@ -268,13 +417,13 @@ def apply_audio_config(audio_files, audio_config, use_word_match=True, dry=False
         file_dir, file_name = os.path.split(file_path)
         matched_info = None  # type: Optional[AudioInfo]
         possible_matches = []
-        for audio_info in audio_config:  # type: AudioInfo
+        for audio_info in audio_config:
             if audio_config.shared:
                 possible_matches.append(audio_config[i])
                 break
             else:
-                clean_info_title = " ".join(clean_words(audio_info.title.lower()))
-                clean_file_name = " ".join(clean_words(file_name.lower()))
+                clean_info_title = " ".join(clean_words(audio_info.title.lower(), aiu.Config.STOPWORDS_RENAME))
+                clean_file_name = " ".join(clean_words(file_name.lower(), aiu.Config.STOPWORDS_RENAME))
                 if clean_info_title in clean_file_name:
                     possible_matches.append(audio_info)
 
@@ -290,14 +439,23 @@ def apply_audio_config(audio_files, audio_config, use_word_match=True, dry=False
 
         matches[file_path] = matched_info
 
-    if use_word_match and any(not match for match in matches.values()):
-        # in the event of very long names, this is often the result of too much metadata written in the name
-        # for example: '[ARTIST] - Some Title (feat. Other) (some version) [album]'
-        # attempt finding a match with the most corresponding words
-        # use only remaining audio files that were not already matched to reduce chances of error
-        leftover_files = list(set(audio_files) - set(match for match in matches if matches[match]))
+    # in the event of very long names, this is often the result of too much metadata written in the file name
+    # for example: '[ARTIST] - Some Title (feat. Other) (some version) [album]'
+    # attempt various heuristics to find a potential alternative file match condition
+    leftover_files = audio_files
+    for use_heuristic, heuristic in [
+        (use_word_match, compute_word_match),
+        (use_tag_match, lambda _files, _audio: compute_tag_match(_files, _audio, word_match=False)),
+        (use_tag_match and use_word_match, lambda _files, _audio: compute_tag_match(_files, _audio, word_match=True)),
+        (use_word_match, check_last_item),
+    ]:
+        leftover_files = list(set(leftover_files) - {match for match in matches if matches[match]})
+        if not leftover_files:
+            break
+        if not use_heuristic:
+            continue
         leftover_audio = [audio_info for audio_info in audio_config if audio_info not in matches.values()]
-        word_matches = compute_word_match(leftover_files, leftover_audio)
+        word_matches = heuristic(leftover_files, leftover_audio)
         matches.update(word_matches)
 
     for file_path in audio_files:
@@ -317,16 +475,16 @@ def apply_audio_config(audio_files, audio_config, use_word_match=True, dry=False
                 if tag.field is not None:
                     setattr(audio_file.tag, tag.field, tag.value)
             if dry:
-                tag_info = list(sorted((k, v) for k, v in matched_info.items() if k not in ['file']))
-                tag_info = [('file', matched_info.file)] + tag_info
-                tags_value_list = '\n'.join('  {}: {}'.format(k, v) for k, v in tag_info)
+                tag_info = list(sorted((k, v) for k, v in matched_info.items() if k not in ["file"]))
+                tag_info = [("file", matched_info.file)] + tag_info
+                tags_value_list = "\n".join('  {}: {}'.format(k, v) for k, v in tag_info)
                 LOGGER.info("Would apply tag updates:\n%s", tags_value_list)
                 continue
             audio_file.tag.save()
         else:
             LOGGER.warning("No audio information was matched for file: [%s]", file_path)
 
-    return audio_config  # FIXME: should return applied with respect to saved audio file tags
+    return audio_config
 
 
 def update_file_names(audio_config, rename_format, rename_title=False, prefix_track=False, dry=False):
@@ -351,8 +509,8 @@ def update_file_names(audio_config, rename_format, rename_title=False, prefix_tr
     if "%(" not in rename_format or ")" not in rename_format:
         LOGGER.error("No rename format or template variable specified! Will not rename anything.")
         return audio_config
-    format_tags = [tag.lower() for tag in re.findall("%\(([A-Za-z_]+)\)s", rename_format)]
-    for audio_item in audio_config:  # type: AudioInfo
+    format_tags = [tag.lower() for tag in re.findall(r"%\(([A-Za-z_]+)\)s", rename_format)]
+    for audio_item in audio_config:
         if audio_item.file:
             if not os.path.isfile(audio_item.file):
                 LOGGER.error("Invalid file value cannot be found: [%s]", audio_item.file)
@@ -373,10 +531,10 @@ def update_file_names(audio_config, rename_format, rename_title=False, prefix_tr
             if dry:
                 LOGGER.info("Would rename [%s] => [%s]", origin_name, rename_norm)
                 continue
-            os.rename(audio_item.file, rename_path)
-            audio_item.file = rename_path
             if origin_name == rename_norm:
                 LOGGER.info("File already named: [%s]", origin_name)
             else:
                 LOGGER.info("Adjusted file name: [%s] => [%s]", origin_name, rename_norm)
+                os.rename(audio_item.file, rename_path)
+                audio_item.file = rename_path
     return audio_config

--- a/config/ignore.cfg
+++ b/config/ignore.cfg
@@ -1,0 +1,7 @@
+# Words that will be ignored when attempting matching between audio configuration and audio files.
+audio
+music
+video
+lyrics
+official
+visualizer

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,7 +22,7 @@ CONFIG_DIR = os.path.join(os.path.dirname(__file__), "configs")
 
 
 def test_parser_config_csv_basic():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-basic.csv"), "csv")
     assert isinstance(config, list)
     assert len(config) == 2
@@ -64,7 +64,7 @@ def test_parser_config_yaml_basic():
 
 
 def test_parser_config_tab_basic():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-tab-basic.txt"), FORMAT_MODE_TAB)
     assert isinstance(config, list)
     assert len(config) == 3
@@ -83,7 +83,7 @@ def test_parser_config_tab_basic():
 
 
 def test_parser_config_tab_numbered():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-tab-number.txt"), FORMAT_MODE_TAB)
     assert isinstance(config, list)
     assert len(config) == 2
@@ -98,7 +98,7 @@ def test_parser_config_tab_numbered():
 
 
 def test_parser_config_tab_crazy():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-tab-crazy.txt"), FORMAT_MODE_TAB)
     tests = [
         ("1", "blah"), ("2", "test"), ("3", "ok"), ("4", "what..."), ("5", "so fly"), ("6", "yep"),
@@ -112,10 +112,10 @@ def test_parser_config_tab_crazy():
 
 
 def test_parser_config_tab_time_and_beautify():
-    aiu.Config.STOPWORDS = []    # ignore
+    aiu.Config.STOPWORDS_RENAME = []    # ignore
     config_raw = parse_audio_config(os.path.join(CONFIG_DIR, "config-tab-time.txt"), FORMAT_MODE_TAB)
-    aiu.Config.STOPWORDS = None  # reset for reload
-    aiu.Config.STOPWORDS = load_config(aiu.Config.STOPWORDS, DEFAULT_STOPWORDS_CONFIG, is_map=False)
+    aiu.Config.STOPWORDS_RENAME = None  # reset for reload
+    aiu.Config.STOPWORDS_RENAME = load_config(aiu.Config.STOPWORDS_RENAME, DEFAULT_STOPWORDS_CONFIG, is_map=False)
     config_clean = parse_audio_config(os.path.join(CONFIG_DIR, "config-tab-time.txt"), FORMAT_MODE_TAB)
     assert isinstance(config_raw, list)
     assert len(config_raw) == 8
@@ -152,7 +152,7 @@ def test_parser_config_tab_time_and_beautify():
 
 
 def test_parser_config_list_both():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-list-both.lst"), FORMAT_MODE_LIST)
     assert isinstance(config, list)
     assert len(config) == 3
@@ -171,7 +171,7 @@ def test_parser_config_list_both():
 
 
 def test_parser_config_list_track():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-list-track.lst"), FORMAT_MODE_LIST)
     assert isinstance(config, list)
     assert len(config) == 3
@@ -190,7 +190,7 @@ def test_parser_config_list_track():
 
 
 def test_parser_config_list_duration():
-    aiu.Config.STOPWORDS = []  # ignore
+    aiu.Config.STOPWORDS_RENAME = []  # ignore
     config = parse_audio_config(os.path.join(CONFIG_DIR, "config-list-duration.lst"), FORMAT_MODE_LIST)
     assert isinstance(config, list)
     assert len(config) == 3

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,61 @@
+import pytest
+
+from aiu.updater import filter_shared_items
+
+
+@pytest.mark.parametrize(
+    ["samples", "expect"],
+    [
+        (
+            [
+                ["test", "test", "test", "other", "value"],
+                ["test", "test", "test", "something", "else"],
+                ["test", "test", "test", "another"],
+            ],
+            [
+                ["other", "value"],
+                ["something", "else"],
+                ["another"],
+            ]
+        ),
+        (
+                [
+                    ["test", "test", "test", "other", "value"],
+                    ["test", "test", "something", "else"],
+                    ["test", "test", "test", "another"],
+                ],
+                [
+                    ["test", "other", "value"],
+                    ["something", "else"],
+                    ["test", "another"],
+                ]
+        ),
+        (
+                [
+                    ["test", "no", "other", "value"],
+                    ["test", "test", "something", "else"],
+                    ["test", "test", "test", "another"],
+                ],
+                [
+                    ["no", "other", "value"],
+                    ["test", "something", "else"],
+                    ["test", "test", "another"],
+                ]
+        ),
+        (
+                [
+                    ["no", "other", "value"],
+                    ["test", "test", "something", "else"],
+                    ["test", "test", "test", "another"],
+                ],
+                [
+                    ["no", "other", "value"],
+                    ["test", "test", "something", "else"],
+                    ["test", "test", "test", "another"],
+                ]
+        )
+    ]
+)
+def test_filter_shared(samples, expect):
+    result = filter_shared_items(samples)
+    assert result == expect


### PR DESCRIPTION
## Changes

* Add search path override to output directory location when the current directory path is detected as the script path.
* Add ``--no-heuristic-tag-match`` and corresponding ``heuristic_tag_match`` flag applied by default that will attempt
  matching existing ID3 tags from the source audio files against target configuration ID3 tags when file names were not
  sufficient to find a match.
* Add more file name matching heuristics to consider duplicated descriptors across multiple file names, in order to
  reduce the set of false-positive candidates using only word portions of the title that are distinct and descriptive.
* Add options ``--heuristic-stopword`` and ``--heuristic-config`` that allows providing a set of stopwords to be ignored
  only during the heuristic file name matching strategy. These allow removing words often found in file names that cause
  noise for the purpose of matching the audio file title. The default file employed if no parameters for these options
  are unspecified is ``aiu/config/ignore.cfg``.
* Rename ``aiu.Config.EXCEPTIONS`` and ``aiu.Config.STOPWORDS`` to ``aiu.Config.EXCEPTIONS_RENAME`` and
  ``aiu.Config.STOPWORDS_RENAME`` respectively to distinguish them from new ``aiu.Config.STOPWORDS_MATCH``
  employed by ``--heuristic-stopword`` and ``--heuristic-config``.
* Add alternative option names ``--rename-exceptions-config`` and ``--rename-stopwords-config`` to corresponding
  ``--exceptions`` and ``--stopwords`` options to provide more explicit representation of their purpose.
* Fix ``heuristic_word_match`` and ``heuristic_delete_duplicates`` flags not passed down for iterative per-album call.
* Apply the resolved ``album_artist`` ID3 tag or its default value set by ``artist`` ID3 tag according to options
  ``--no-match-artist`` and ``--album-artist`` as detailed in their description.
* Fix default value of ``match_artist``, set when omitting ``-no-match-artist`` that caused ``--album-artist`` value
  provided explicitly to be ignored.
* Remove duplicate and unimplemented function for applying ID3 tags.
* Move ID3 tag and cover file utilities from ``aiu.utils`` to ``aiu.updater`` module.
* Fix ID3 tags properties passed by individual options (``-A``, ``-T``, etc.) to be incorrectly reported in the logging
  definition, as well as passing them as individual ``AudioInfo`` objects instead of a single combined one under the
  generated ``AudioConfig`` for these tags. If more than one literal ID3 tag field was provided simultaneously, this
  would cause erroneous mismatches in length comparison between multiple ``AudioConfig`` from the various sources.
* Fix logging calls not using the lazy string evaluation format in some cases.